### PR TITLE
Record test output value

### DIFF
--- a/src/darjeeling/core.py
+++ b/src/darjeeling/core.py
@@ -126,23 +126,27 @@ class Test:
 @attr.s(frozen=True, slots=True, auto_attribs=True)
 class TestOutcome:
     """Records the outcome of a test execution."""
+    name: str
     successful: bool
     time_taken: float
     output: str
 
     @staticmethod
     def from_bugzoo(outcome: BugZooTestOutcome) -> 'TestOutcome':
-        return TestOutcome(successful=outcome.passed,
+        return TestOutcome(name="???", successful=outcome.passed,
                            time_taken=outcome.duration,
                            output=None)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> 'TestOutcome':
-        return TestOutcome(d['successful'], d['time-taken'],
-                d.get("output", None))
+    def from_dict(d: Dict[str, Any], name=None) -> 'TestOutcome':
+        if name is None:
+            name = "???"
+        return TestOutcome(d.get('name', name), d['successful'], 
+                d['time-taken'], d.get('output', None))
 
     def to_dict(self) -> Dict[str, Any]:
-        return {'successful': self.successful,
+        return {'name': self.name,
+                'successful': self.successful,
                 'time-taken': self.time_taken,
                 'output': self.output}
 
@@ -205,7 +209,7 @@ class TestCoverage:
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> 'TestCoverage':
         name = d['name']
-        outcome = TestOutcome.from_dict(d['outcome'])
+        outcome = TestOutcome.from_dict(d['outcome'], name)
         lines = FileLineSet.from_dict(d['lines'])
         return TestCoverage(name, outcome, lines)
 

--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -159,7 +159,8 @@ class Evaluator(DarjeelingEventProducer):
                              f"candidate [{candidate}]")
             self.dispatch(TestExecutionError(candidate, test, err))
             outcome = TestOutcome(successful=False,
-                                  time_taken=timer.duration)
+                                  time_taken=timer.duration,
+                                  output=None)
 
         if not outcome.successful:
             logger.debug(f"* test failed: {test.name} ({candidate})")
@@ -182,7 +183,7 @@ class Evaluator(DarjeelingEventProducer):
 
         # compute outcomes for redundant tests
         test_outcomes = TestOutcomeSet({
-            t.name: TestOutcome(True, 0.0) for t in redundant
+            t.name: TestOutcome(True, 0.0, None) for t in redundant
         })  # type: TestOutcomeSet
 
         # if we have evidence that this patch is not a complete repair,

--- a/src/darjeeling/evaluator.py
+++ b/src/darjeeling/evaluator.py
@@ -158,7 +158,8 @@ class Evaluator(DarjeelingEventProducer):
                              f"test [{test.name}] for "
                              f"candidate [{candidate}]")
             self.dispatch(TestExecutionError(candidate, test, err))
-            outcome = TestOutcome(successful=False,
+            outcome = TestOutcome(test.name,
+                                  successful=False,
                                   time_taken=timer.duration,
                                   output=None)
 
@@ -183,7 +184,7 @@ class Evaluator(DarjeelingEventProducer):
 
         # compute outcomes for redundant tests
         test_outcomes = TestOutcomeSet({
-            t.name: TestOutcome(True, 0.0, None) for t in redundant
+            t.name: TestOutcome(t.name, True, 0.0, None) for t in redundant
         })  # type: TestOutcomeSet
 
         # if we have evidence that this patch is not a complete repair,

--- a/src/darjeeling/outcome.py
+++ b/src/darjeeling/outcome.py
@@ -32,7 +32,7 @@ class CandidateOutcome:
                           output: str,
                           time_taken: float
                           ) -> 'CandidateOutcome':
-        outcome = TestOutcome(successful, time_taken, output)
+        outcome = TestOutcome(test, successful, time_taken, output)
         test_outcomes = self.tests.with_outcome(test, outcome)
         return CandidateOutcome(self.build, test_outcomes, self.is_repair)
 

--- a/src/darjeeling/outcome.py
+++ b/src/darjeeling/outcome.py
@@ -29,9 +29,10 @@ class CandidateOutcome:
     def with_test_outcome(self,
                           test: str,
                           successful: bool,
+                          output: str,
                           time_taken: float
                           ) -> 'CandidateOutcome':
-        outcome = TestOutcome(successful, time_taken)
+        outcome = TestOutcome(successful, time_taken, output)
         test_outcomes = self.tests.with_outcome(test, outcome)
         return CandidateOutcome(self.build, test_outcomes, self.is_repair)
 

--- a/src/darjeeling/searcher/base.py
+++ b/src/darjeeling/searcher/base.py
@@ -127,7 +127,7 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
             results[candidate] = outcome
             num_evaluated += 1
             if outcome.is_repair:
-                yield candidate
+                yield candidate, outcome
             if i < size:
                 self.evaluate(candidates[i])
                 i += 1
@@ -169,7 +169,7 @@ class Searcher(DarjeelingEventProducer, abc.ABC):
         for candidate, outcome in self.as_evaluated():
             if outcome.is_repair:
                 stopwatch.stop()
-                yield candidate
+                yield candidate, outcome
                 stopwatch.start()
 
         stopwatch.stop()

--- a/src/darjeeling/searcher/exhaustive.py
+++ b/src/darjeeling/searcher/exhaustive.py
@@ -96,5 +96,5 @@ class ExhaustiveSearcher(Searcher):
 
         for candidate, outcome in self.as_evaluated():
             if outcome.is_repair:
-                yield candidate
+                yield candidate, outcome
             self.evaluate(self._generate())

--- a/src/darjeeling/test/genprog.py
+++ b/src/darjeeling/test/genprog.py
@@ -98,5 +98,5 @@ class GenProgTestSuite(TestSuite[GenProgTest]):
         else:
             output = None
 
-        return TestOutcome(successful=successful, time_taken=outcome.duration,
-                output=output)
+        return TestOutcome(test.name, successful=successful, 
+                time_taken=outcome.duration, output=output)

--- a/src/darjeeling/test/pytest.py
+++ b/src/darjeeling/test/pytest.py
@@ -85,6 +85,7 @@ class PyTestSuite(TestSuite[PyTestCase]):
         else:
             output = None
 
-        return TestOutcome(successful=successful, 
+        return TestOutcome(test.name, 
+                successful=successful, 
                 time_taken=outcome.duration,
                 output=output)

--- a/tests/test_coverage.py
+++ b/tests/test_coverage.py
@@ -13,8 +13,10 @@ def ln(num: int) -> FileLine:
 
 @pytest.fixture
 def coverage() -> TestCoverage:
-    outcome = TestOutcome(successful=True,
-                          time_taken=0.35)
+    outcome = TestOutcome(name="foo",
+                          successful=True,
+                          time_taken=0.35,
+                          output="42")
     lines = FileLineSet.from_list([ln(1), ln(2), ln(3)])
     return TestCoverage(test='foo',
                         outcome=outcome,

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -17,14 +17,16 @@ class TestOutcome:
 
     @staticmethod
     def from_bugzoo(outcome: BugZooTestOutcome) -> 'TestOutcome':
-        return TestOutcome(successful=outcome.passed,
+        return TestOutcome(name="???", successful=outcome.passed,
                            time_taken=outcome.duration,
                            output=None)
 
     @staticmethod
-    def from_dict(d: Dict[str, Any]) -> 'TestOutcome':
-        return TestOutcome(d['successful'], d['time-taken'],
-            d.get('output', None))
+    def from_dict(d: Dict[str, Any], name:str=None) -> 'TestOutcome':
+        if name is None:
+            name = "???"
+        return TestOutcome(d.get('name', name), d['successful'], 
+                d['time-taken'], d.get('output', None))
 
     def to_dict(self) -> Dict[str, Any]:
         return {'successful': self.successful,

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -18,11 +18,13 @@ class TestOutcome:
     @staticmethod
     def from_bugzoo(outcome: BugZooTestOutcome) -> 'TestOutcome':
         return TestOutcome(successful=outcome.passed,
-                           time_taken=outcome.duration)
+                           time_taken=outcome.duration,
+                           output=None)
 
     @staticmethod
     def from_dict(d: Dict[str, Any]) -> 'TestOutcome':
-        return TestOutcome(d['successful'], d['time-taken'])
+        return TestOutcome(d['successful'], d['time-taken'],
+            d.get('output', None))
 
     def to_dict(self) -> Dict[str, Any]:
         return {'successful': self.successful,


### PR DESCRIPTION
Now test information is recorded along with the patches in the repair process. Also fixed instantiation of TestOutcome objects in parts of the code I missed in the previous changes.